### PR TITLE
Increase memo size for jetton transactions up to 127 characters

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tonsdk
-version = 1.0.13
+version = 1.1.0
 description = Python SDK for TON
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tonsdk/contract/token/ft/jetton_wallet.py
+++ b/tonsdk/contract/token/ft/jetton_wallet.py
@@ -30,9 +30,15 @@ class JettonWallet(Contract):
         cell.bits.write_address(response_address or to_address)
         cell.bits.write_bit(0)  # null custom_payload
         cell.bits.write_grams(forward_amount)
-        cell.bits.write_bit(0)  # forward_payload in this slice, not separate cell
-        if forward_payload:
-            cell.bits.write_bytes(forward_payload)
+        if not forward_payload or len(forward_payload) < 40:
+            cell.bits.write_bit(0)  # forward_payload in this slice, not separate cell
+            if forward_payload:
+                cell.bits.write_bytes(forward_payload)
+        else:
+            forward_payload_cell = Cell()
+            forward_payload_cell.bits.write_bytes(forward_payload)
+            cell.bits.write_bit(1) # forward_payload in another cell
+            cell.refs.append(forward_payload_cell)
 
         return cell
 


### PR DESCRIPTION
Currently we can send memo for jetton transaction up to 39 char, in this PR it is increased up to 127 char, by storing memo in another cell.