### PR TITLE
Allow initializing wallet using just public key or just private key

### DIFF
--- a/tonsdk/contract/wallet/_wallet_contract.py
+++ b/tonsdk/contract/wallet/_wallet_contract.py
@@ -20,7 +20,7 @@ class SendModeEnum(int, Enum):
 
 class WalletContract(Contract):
     def __init__(self, **kwargs):
-        if (("public_key" not in kwargs or "private_key" not in kwargs) and "address" not in kwargs) and 'public_keys' not in kwargs:
+        if (("public_key" not in kwargs and "private_key" not in kwargs) and "address" not in kwargs) and 'public_keys' not in kwargs:
             raise Exception(
                 "WalletContract required publicKey or address in options")
         super().__init__(**kwargs)


### PR DESCRIPTION
If wallet can be initialized just using the address, then it should also allow initialization just using public key.
I believe this was a typo.