### PR TITLE
Store large comment for jetton transfer into separated cell

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tonsdk
-version = 1.0.13
+version = 1.0.14
 description = Python SDK for TON
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tonsdk/contract/token/ft/jetton_wallet.py
+++ b/tonsdk/contract/token/ft/jetton_wallet.py
@@ -30,9 +30,18 @@ class JettonWallet(Contract):
         cell.bits.write_address(response_address or to_address)
         cell.bits.write_bit(0)  # null custom_payload
         cell.bits.write_grams(forward_amount)
-        cell.bits.write_bit(0)  # forward_payload in this slice, not separate cell
+
         if forward_payload:
-            cell.bits.write_bytes(forward_payload)
+            forward_payload_cell = Cell()
+            forward_payload_cell.bits.write_bytes(forward_payload)
+            if cell.bits.get_free_bits() > forward_payload_cell.bits.get_used_bits():
+                cell.bits.write_bit(0)
+                cell.write_cell(forward_payload_cell)
+            else:
+                cell.bits.write_bit(1)
+                cell.refs.append(forward_payload_cell)
+        else:
+            cell.bits.write_bit(0)
 
         return cell
 


### PR DESCRIPTION
Store comment into jetton transfer message if it has enough space, and store into another cell if it don't have enough space in base cell.